### PR TITLE
Lucid view builder

### DIFF
--- a/examples/playground/app/src/Nauva/Playground/App.hs
+++ b/examples/playground/app/src/Nauva/Playground/App.hs
@@ -108,8 +108,8 @@ component = Component
 
     view (i, t) = ENode "span" Nothing [] [] noStyle
         [ EText $ "Component " <> (T.pack $ show i)
-        , ENode "button" Nothing [Attribute "value" (AVString "TheButtonValue")] [onClick onClickHandler] noStyle [EText "Click Me!"]
-        , ENode "input" Nothing [Attribute "value" (AVString t)] [onChange onChangeHandler] noStyle []
+        , ENode "button" Nothing [stringAttribute "value" "TheButtonValue"] [onClick onClickHandler] noStyle [EText "Click Me!"]
+        , ENode "input" Nothing [stringAttribute "value" t] [onChange onChangeHandler] noStyle []
         , EText t
         ]
 
@@ -233,7 +233,7 @@ canvas = Component
         ]
 
     svg ((x,y), (width, height)) = ENode "svg" Nothing
-        [Attribute "width" (AVInt width), Attribute "height" (AVInt height), stringAttribute "className" "canvas"]
+        [intAttribute "width" width, intAttribute "height" height, stringAttribute "className" "canvas"]
         [onMouseMove onMouseMoveHandler] svgStyle $
         [ ENode "rect" Nothing [intAttribute "x" 0, intAttribute "y" 0, intAttribute "width" width, intAttribute "height" height, stringAttribute "fill" "#DDD"] [] noStyle []
         , ENode "circle" Nothing [intAttribute "r" 12, stringAttribute "cx" (T.pack $ show x), stringAttribute "cy" (T.pack $ show y), stringAttribute "fill" "magenta"] [] noStyle []

--- a/examples/playground/app/src/Nauva/Playground/App.hs
+++ b/examples/playground/app/src/Nauva/Playground/App.hs
@@ -30,14 +30,14 @@ import           Nauva.NJS
 -- contains both 'Thunk's and 'Component's, to demonstrate that they all work
 -- as expected (ie. 'Thunk's are forced and 'Components' retain their state).
 rootElement :: Int -> Element
-rootElement i = ENode "div" Nothing [] [] rootStyle $
+rootElement i = ENode "div" Nothing [styleAttribute rootStyle] [] noStyle $
     [ EText $ "App Generation " <> (T.pack $ show i)
     , ENode "br" Nothing [] [] noStyle []
     , EThunk thunk (i `div` 2)
     , ENode "br" Nothing [] [] noStyle []
     , EComponent component (i `div` 3)
     , ENode "br" Nothing [] [] noStyle []
-    , ENode "div" Nothing [] [] (M.fromList [ ("flex", "1"), ("display", "flex"), ("flex-direction", "row") ]) $
+    , ENode "div" Nothing [styleAttribute canvasContainerStyle] [] noStyle $
         [ EComponent canvas ()
         , EComponent canvas ()
         ]
@@ -49,6 +49,12 @@ rootElement i = ENode "div" Nothing [] [] rootStyle $
         [ ("height", "100vh")
         , ("display", "flex")
         , ("flex-direction", "column")
+        ]
+
+    canvasContainerStyle = M.fromList
+        [ ("flex", "1")
+        , ("display", "flex")
+        , ("flex-direction", "row")
         ]
 
 
@@ -108,8 +114,8 @@ component = Component
 
     view (i, t) = ENode "span" Nothing [] [] noStyle
         [ EText $ "Component " <> (T.pack $ show i)
-        , ENode "button" Nothing [stringAttribute "value" "TheButtonValue"] [onClick onClickHandler] noStyle [EText "Click Me!"]
-        , ENode "input" Nothing [stringAttribute "value" t] [onChange onChangeHandler] noStyle []
+        , ENode "button" Nothing [eventListenerAttribute (onClick onClickHandler), stringAttribute "value" "TheButtonValue"] [] noStyle [EText "Click Me!"]
+        , ENode "input" Nothing [eventListenerAttribute (onChange onChangeHandler), stringAttribute "value" t] [] noStyle []
         , EText t
         ]
 
@@ -222,7 +228,7 @@ canvas = Component
     detach = F1 mkFID $ \_ -> refHandlerE nothingE
 
     view :: CanvasS -> Element
-    view (CanvasS (x,y) refKey _ s) = ENode "div" (Just $ Ref (Just refKey) attach detach) [] [] style $
+    view (CanvasS (x,y) refKey _ s) = ENode "div" Nothing [styleAttribute style, refAttribute (Ref (Just refKey) attach detach)] [] noStyle $
         case s of
             Nothing -> []
             Just (w,h) -> [svg ((x,y), (w, h))]
@@ -233,8 +239,8 @@ canvas = Component
         ]
 
     svg ((x,y), (width, height)) = ENode "svg" Nothing
-        [intAttribute "width" width, intAttribute "height" height, stringAttribute "className" "canvas"]
-        [onMouseMove onMouseMoveHandler] svgStyle $
+        [styleAttribute svgStyle, eventListenerAttribute (onMouseMove onMouseMoveHandler), intAttribute "width" width, intAttribute "height" height, stringAttribute "className" "canvas"]
+        [] noStyle $
         [ ENode "rect" Nothing [intAttribute "x" 0, intAttribute "y" 0, intAttribute "width" width, intAttribute "height" height, stringAttribute "fill" "#DDD"] [] noStyle []
         , ENode "circle" Nothing [intAttribute "r" 12, stringAttribute "cx" (T.pack $ show x), stringAttribute "cy" (T.pack $ show y), stringAttribute "fill" "magenta"] [] noStyle []
         ] ++ circles (width, height) (floor x)

--- a/examples/playground/app/src/Nauva/Playground/App.hs
+++ b/examples/playground/app/src/Nauva/Playground/App.hs
@@ -30,14 +30,14 @@ import           Nauva.NJS
 -- contains both 'Thunk's and 'Component's, to demonstrate that they all work
 -- as expected (ie. 'Thunk's are forced and 'Components' retain their state).
 rootElement :: Int -> Element
-rootElement i = ENode "div" Nothing [styleAttribute rootStyle] [] noStyle $
+rootElement i = ENode "div" [styleAttribute rootStyle] $
     [ EText $ "App Generation " <> (T.pack $ show i)
-    , ENode "br" Nothing [] [] noStyle []
+    , ENode "br" [] []
     , EThunk thunk (i `div` 2)
-    , ENode "br" Nothing [] [] noStyle []
+    , ENode "br" [] []
     , EComponent component (i `div` 3)
-    , ENode "br" Nothing [] [] noStyle []
-    , ENode "div" Nothing [styleAttribute canvasContainerStyle] [] noStyle $
+    , ENode "br" [] []
+    , ENode "div" [styleAttribute canvasContainerStyle] $
         [ EComponent canvas ()
         , EComponent canvas ()
         ]
@@ -112,10 +112,10 @@ component = Component
 
     receiveProps' p (_, t) = ((p, t), [pure DoThat])
 
-    view (i, t) = ENode "span" Nothing [] [] noStyle
+    view (i, t) = ENode "span" []
         [ EText $ "Component " <> (T.pack $ show i)
-        , ENode "button" Nothing [eventListenerAttribute (onClick onClickHandler), stringAttribute "value" "TheButtonValue"] [] noStyle [EText "Click Me!"]
-        , ENode "input" Nothing [eventListenerAttribute (onChange onChangeHandler), stringAttribute "value" t] [] noStyle []
+        , ENode "button" [eventListenerAttribute (onClick onClickHandler), stringAttribute "value" "TheButtonValue"] [EText "Click Me!"]
+        , ENode "input" [eventListenerAttribute (onChange onChangeHandler), stringAttribute "value" t] []
         , EText t
         ]
 
@@ -211,12 +211,12 @@ canvas = Component
     circles (width, height) n = flip map [1..numCircles] $ \i ->
         let (x, stdGen) = next (mkStdGen $ n + i)
             (y, _     ) = next stdGen
-        in ENode "circle" Nothing
+        in ENode "circle"
             [ intAttribute "r" 6
             , intAttribute "cx" (x `mod` width)
             , intAttribute "cy" (y `mod` height)
             , stringAttribute "fill" "black"
-            ] [] noStyle []
+            ] []
 
     -- attach = refHandler $ \componentH element -> do
     --     storeRef componentH (litE "svg") element
@@ -228,7 +228,7 @@ canvas = Component
     detach = F1 mkFID $ \_ -> refHandlerE nothingE
 
     view :: CanvasS -> Element
-    view (CanvasS (x,y) refKey _ s) = ENode "div" Nothing [styleAttribute style, refAttribute (Ref (Just refKey) attach detach)] [] noStyle $
+    view (CanvasS (x,y) refKey _ s) = ENode "div" [styleAttribute style, refAttribute (Ref (Just refKey) attach detach)] $
         case s of
             Nothing -> []
             Just (w,h) -> [svg ((x,y), (w, h))]
@@ -238,11 +238,10 @@ canvas = Component
         , ("display", "flex")
         ]
 
-    svg ((x,y), (width, height)) = ENode "svg" Nothing
-        [styleAttribute svgStyle, eventListenerAttribute (onMouseMove onMouseMoveHandler), intAttribute "width" width, intAttribute "height" height, stringAttribute "className" "canvas"]
-        [] noStyle $
-        [ ENode "rect" Nothing [intAttribute "x" 0, intAttribute "y" 0, intAttribute "width" width, intAttribute "height" height, stringAttribute "fill" "#DDD"] [] noStyle []
-        , ENode "circle" Nothing [intAttribute "r" 12, stringAttribute "cx" (T.pack $ show x), stringAttribute "cy" (T.pack $ show y), stringAttribute "fill" "magenta"] [] noStyle []
+    svg ((x,y), (width, height)) = ENode "svg"
+        [styleAttribute svgStyle, eventListenerAttribute (onMouseMove onMouseMoveHandler), intAttribute "width" width, intAttribute "height" height, stringAttribute "className" "canvas"] $
+        [ ENode "rect" [intAttribute "x" 0, intAttribute "y" 0, intAttribute "width" width, intAttribute "height" height, stringAttribute "fill" "#DDD"] []
+        , ENode "circle" [intAttribute "r" 12, stringAttribute "cx" (T.pack $ show x), stringAttribute "cy" (T.pack $ show y), stringAttribute "fill" "magenta"] []
         ] ++ circles (width, height) (floor x)
 
     svgStyle = M.fromList

--- a/pkg/hs/nauva-dev-server/public/nauva-dev-server.js
+++ b/pkg/hs/nauva-dev-server/public/nauva-dev-server.js
@@ -213,8 +213,8 @@ function spineToReact(ws, path, ctx, spine, key) {
     }
     else if (spine.type === 'Node') {
         const children = spine.children.map(([index, child]) => spineToReact(ws, [].concat(path, index), ctx, child, index));
-        const props = { key, style: spine.style };
-        spine.eventListeners.forEach(([fid, name, expr]) => {
+        const props = { key };
+        const installEventListener = ([fid, name, expr]) => {
             props[`on${capitalizeFirstLetter(name)}`] = getFn(ctx, path, fid, () => {
                 console.log('getFn', fid, name);
                 return ev => {
@@ -227,37 +227,45 @@ function spineToReact(ws, path, ctx, spine, key) {
                     }
                 };
             });
-        });
-        for (const [p, v] of spine.attributes) {
-            props[p] = v;
-        }
-        if (spine.ref) {
-            props.ref = getFn(ctx, path, 'ref', () => {
-                console.log('getFn ref');
-                return ref => {
-                    if (ref === null) {
-                        // spine.ref.detach;
-                        if (spine.ref.key) {
-                            ctx.refs.delete(spine.ref.key);
+        };
+        for (const [k, a, b] of spine.attributes) {
+            if (k === 'AVAL') {
+                props[a] = b;
+            }
+            else if (k === 'AEVL') {
+                installEventListener(a);
+            }
+            else if (k === 'ASTY') {
+                props.style = a;
+            }
+            else if (k === 'AREF') {
+                props.ref = getFn(ctx, path, 'ref', () => {
+                    console.log('getFn ref', a);
+                    return ref => {
+                        if (ref === null) {
+                            // spine.ref.detach;
+                            if (a.key) {
+                                ctx.refs.delete(a.key);
+                            }
+                            console.log('detach');
+                            const r = evalExp(a.detach, { ['1']: ref }, this.ctx);
+                            if (r.action) {
+                                ws.send(JSON.stringify(['ref', path, r.action]));
+                            }
                         }
-                        console.log('detach');
-                        const r = evalExp(spine.ref.detach, { ['1']: ref }, this.ctx);
-                        if (r.action) {
-                            ws.send(JSON.stringify(['ref', path, r.action]));
+                        else {
+                            if (a.key) {
+                                ctx.refs.set(a.key, ref);
+                            }
+                            console.log('attach');
+                            const r = evalExp(a.attach, { ['1']: ref }, this.ctx);
+                            if (r.action) {
+                                ws.send(JSON.stringify(['ref', path, r.action]));
+                            }
                         }
-                    }
-                    else {
-                        if (spine.ref.key) {
-                            ctx.refs.set(spine.ref.key, ref);
-                        }
-                        console.log('attach');
-                        const r = evalExp(spine.ref.attach, { ['1']: ref }, this.ctx);
-                        if (r.action) {
-                            ws.send(JSON.stringify(['ref', path, r.action]));
-                        }
-                    }
-                };
-            });
+                    };
+                });
+            }
         }
         if (spine.tag === 'input') {
             return React.createElement(ControlledInput, {

--- a/pkg/hs/nauva-native/jsbits/bridge.ts
+++ b/pkg/hs/nauva-native/jsbits/bridge.ts
@@ -184,30 +184,35 @@ function spineToReact(clientH: ClientH, path, ctx: Context, spine, key) {
             spineToReact(clientH, [].concat(path, index), ctx, child, index)
         );
 
-        const props: any = { key, style: spine.style };
-        spine.eventListeners.forEach(([fid, name]) => {
+        const props: any = { key };
+
+        const installEventListener = (fid, name) => {
             props[`on${capitalizeFirstLetter(name)}`] = getFn(ctx, path, fid, () => {
                 console.log('getFn', fid, name);
                 return ev => {
                     clientH.dispatchNodeEvent(path, fid, ev);
                 };
             });
-        });
+        };
 
-        for (const [p,v] of spine.attributes) {
-            props[p] = v;
-        }
-
-        if (spine.ref) {
-            props.ref = getFn(ctx, path, 'ref', () => {
-                return ref => {
-                    if (ref === null) {
-                        clientH.detachRef(path);
-                    } else {
-                        clientH.attachRef(path, ref);
-                    }
-                };
-            });
+        for (const [k, a, b] of spine.attributes) {
+            if (k === 'AVAL') {
+                props[a] = b;
+            } else if (k === 'AEVL') {
+                installEventListener(a, b);
+            } else if (k === 'ASTY') {
+                props.style = a;
+            } else if (k === 'AREF') {
+                props.ref = getFn(ctx, path, 'ref', () => {
+                    return ref => {
+                        if (ref === null) {
+                            clientH.detachRef(path);
+                        } else {
+                            clientH.attachRef(path, ref);
+                        }
+                    };
+                });
+            }
         }
 
         if (spine.tag === 'input') {

--- a/pkg/hs/nauva-native/jsbits/index.js
+++ b/pkg/hs/nauva-native/jsbits/index.js
@@ -142,31 +142,38 @@ function spineToReact(clientH, path, ctx, spine, key) {
             var index = _a[0], child = _a[1];
             return spineToReact(clientH, [].concat(path, index), ctx, child, index);
         });
-        var props_1 = { key: key, style: spine.style };
-        spine.eventListeners.forEach(function (_a) {
-            var fid = _a[0], name = _a[1];
+        var props_1 = { key: key };
+        var installEventListener = function (fid, name) {
             props_1[("on" + capitalizeFirstLetter(name))] = getFn(ctx, path, fid, function () {
                 console.log('getFn', fid, name);
                 return function (ev) {
                     clientH.dispatchNodeEvent(path, fid, ev);
                 };
             });
-        });
+        };
         for (var _i = 0, _a = spine.attributes; _i < _a.length; _i++) {
-            var _b = _a[_i], p = _b[0], v = _b[1];
-            props_1[p] = v;
-        }
-        if (spine.ref) {
-            props_1.ref = getFn(ctx, path, 'ref', function () {
-                return function (ref) {
-                    if (ref === null) {
-                        clientH.detachRef(path);
-                    }
-                    else {
-                        clientH.attachRef(path, ref);
-                    }
-                };
-            });
+            var _b = _a[_i], k = _b[0], a = _b[1], b = _b[2];
+            if (k === 'AVAL') {
+                props_1[a] = b;
+            }
+            else if (k === 'AEVL') {
+                installEventListener(a, b);
+            }
+            else if (k === 'ASTY') {
+                props_1.style = a;
+            }
+            else if (k === 'AREF') {
+                props_1.ref = getFn(ctx, path, 'ref', function () {
+                    return function (ref) {
+                        if (ref === null) {
+                            clientH.detachRef(path);
+                        }
+                        else {
+                            clientH.attachRef(path, ref);
+                        }
+                    };
+                });
+            }
         }
         if (spine.tag === 'input') {
             return React.createElement.apply(React, [ControlledInput, {

--- a/pkg/hs/nauva-native/src/Nauva/Client.hs
+++ b/pkg/hs/nauva-native/src/Nauva/Client.hs
@@ -338,7 +338,10 @@ instanceToJSVal = go []
 
                         pure $ jsval o
 
-            eventListeners' <- pure $ jsval $ fromList $ flip map eventListeners $ \el -> case el of
+            let evls = catMaybes $ map (\x -> case x of
+                        AEVL el -> Just el
+                        _       -> Nothing) attrs
+            eventListeners' <- pure $ jsval $ fromList $ flip map (eventListeners <> evls) $ \el -> case el of
                 (EventListener n fe) -> jsval $ fromList [js_intJSVal $ unFID $ f1Id fe, jsval $ textToJSString n]
 
             pure $ unsafePerformIO $ do
@@ -349,7 +352,11 @@ instanceToJSVal = go []
                 forM_ (M.toList style) $ \(k, v) ->
                     O.setProp (JSS.pack k) (jsval $ JSS.pack v) style'
 
-                attributes' <- pure $ jsval $ fromList $ flip map attrs $ \(Attribute an av) ->
+                let avals = catMaybes $ map (\x -> case x of
+                        AVAL an av -> Just $ (an, av)
+                        _          -> Nothing) attrs
+
+                attributes' <- pure $ jsval $ fromList $ flip map avals $ \(an, av) ->
                     case av of
                         AVBool b   -> jsval $ fromList [jsval $ textToJSString an, if b then js_true else js_false]
                         AVString s -> jsval $ fromList [jsval $ textToJSString an, jsval $ textToJSString s]

--- a/pkg/hs/nauva-native/src/Nauva/Client.hs
+++ b/pkg/hs/nauva-native/src/Nauva/Client.hs
@@ -161,13 +161,22 @@ componentWillUnmountHandler :: Nauva.Handle.Handle -> Path -> IO (Either String 
 componentWillUnmountHandler = hookHandler componentWillUnmount
 
 
+refFromAttributes :: [Attribute] -> Maybe Ref
+refFromAttributes attrs = case catMaybes (map unRef attrs) of
+    ref:_ -> Just ref
+    _     -> Nothing
+  where
+    unRef (AREF x) = Just x
+    unRef _        = Nothing
+
 
 attachRefHandler :: Nauva.Handle.Handle -> TVar (Map (ComponentId, RefKey) JSVal) -> Path -> JSVal -> IO (Either String ())
 attachRefHandler h refsVar path jsVal = do
     res <- atomically $ runExceptT $ do
         (mbSCI, inst) <- contextForPath h path
         case (mbSCI, inst) of
-            (Just (SomeComponentInstance ci@(ComponentInstance ciPath component stateRef)), INode _ mbRef _ _ _ _) -> do
+            (Just (SomeComponentInstance ci@(ComponentInstance ciPath component stateRef)), INode _ attrs _) -> do
+                let mbRef = refFromAttributes attrs
                 let mbRefKey = mbRef >>= \(Ref mbRefKey _ _) -> mbRefKey
                 case mbRefKey of
                     Nothing -> pure ()
@@ -200,7 +209,8 @@ detachRefHandler h refsVar path = do
     res <- atomically $ runExceptT $ do
         (mbSCI, inst) <- contextForPath h path
         case (mbSCI, inst) of
-            (Just (SomeComponentInstance ci@(ComponentInstance ciPath component stateRef)), INode _ mbRef _ _ _ _) -> do
+            (Just (SomeComponentInstance ci@(ComponentInstance ciPath component stateRef)), INode _ attrs _) -> do
+                let mbRef = refFromAttributes attrs
                 let mbRefKey = mbRef >>= \(Ref mbRefKey _ _) -> mbRefKey
                 case mbRefKey of
                     Nothing -> pure ()
@@ -231,7 +241,8 @@ dispatchNodeEventHandler h refsVar path fid ev = do
     res <- atomically $ runExceptT $ do
         (mbSCI, inst) <- contextForPath h path
         case (mbSCI, inst) of
-            (Just (SomeComponentInstance ci@(ComponentInstance ciPath component stateRef)), INode tag _ _ eventListeners _ _) -> do
+            (Just (SomeComponentInstance ci@(ComponentInstance ciPath component stateRef)), INode tag attrs _) -> do
+                let eventListeners = catMaybes $ map (\x -> case x of (AEVL el) -> Just el; _ -> Nothing) attrs
                 ctxRefs <- do
                     x <- lift $ readTVar refsVar
                     pure $ M.fromList $ map (\((_,k),v) -> (k,v)) $ M.toList x
@@ -314,7 +325,7 @@ instanceToJSVal = go []
     go path inst = case inst of
         (IText text) -> pure $ jsval $ textToJSString text
 
-        (INode tag ref attrs eventListeners style children) -> do
+        (INode tag attrs children) -> do
             newChildren <- forM children $ \(key, childI) -> do
                 newChild <- instanceToJSVal childI
                 key' <- case key of
@@ -323,10 +334,26 @@ instanceToJSVal = go []
 
                 pure $ jsval $ fromList [key', newChild]
 
-            ref' <- case ref of
-                Nothing -> pure $ nullRef
-                Just (Ref mbRefKey fra frd) -> do
-                    pure $ unsafePerformIO $ do
+
+            pure $ unsafePerformIO $ do
+                o <- O.create
+
+                attributes' <- pure $ jsval $ fromList $ flip map attrs $ \x -> case x of
+                    AVAL an (AVBool b)        -> jsval $ fromList [jsval $ textToJSString "AVAL", jsval $ textToJSString an, if b then js_true else js_false] 
+                    AVAL an (AVString s)      -> jsval $ fromList [jsval $ textToJSString "AVAL", jsval $ textToJSString an, jsval $ textToJSString s]
+                    AVAL an (AVInt i)         -> jsval $ fromList [jsval $ textToJSString "AVAL", jsval $ textToJSString an, js_intJSVal i]
+
+                    AEVL (EventListener n fe) -> jsval $ fromList [jsval $ textToJSString "AEVL", js_intJSVal $ unFID $ f1Id fe, jsval $ textToJSString n]
+
+                    ASTY style -> unsafePerformIO $ do
+                        style' <- O.create
+
+                        forM_ (M.toList style) $ \(k, v) ->
+                            O.setProp (JSS.pack k) (jsval $ JSS.pack v) style'
+
+                        pure $ jsval $ fromList [jsval $ textToJSString "ASTY", (jsval style')]
+
+                    AREF (Ref mbRefKey fra frd) -> unsafePerformIO $ do
                         o <- O.create
                 
                         case mbRefKey of
@@ -336,39 +363,11 @@ instanceToJSVal = go []
                         O.setProp "attach" (js_intJSVal $ unFID $ f2Id fra) o
                         O.setProp "detach" (js_intJSVal $ unFID $ f1Id frd) o
 
-                        pure $ jsval o
-
-            let evls = catMaybes $ map (\x -> case x of
-                        AEVL el -> Just el
-                        _       -> Nothing) attrs
-            eventListeners' <- pure $ jsval $ fromList $ flip map (eventListeners <> evls) $ \el -> case el of
-                (EventListener n fe) -> jsval $ fromList [js_intJSVal $ unFID $ f1Id fe, jsval $ textToJSString n]
-
-            pure $ unsafePerformIO $ do
-                o <- O.create
-
-                style' <- O.create
-
-                forM_ (M.toList style) $ \(k, v) ->
-                    O.setProp (JSS.pack k) (jsval $ JSS.pack v) style'
-
-                let avals = catMaybes $ map (\x -> case x of
-                        AVAL an av -> Just $ (an, av)
-                        _          -> Nothing) attrs
-
-                attributes' <- pure $ jsval $ fromList $ flip map avals $ \(an, av) ->
-                    case av of
-                        AVBool b   -> jsval $ fromList [jsval $ textToJSString an, if b then js_true else js_false]
-                        AVString s -> jsval $ fromList [jsval $ textToJSString an, jsval $ textToJSString s]
-                        AVInt i    -> jsval $ fromList [jsval $ textToJSString an, js_intJSVal i]
-                        -- AVDouble d -> jsval $ fromList [jsval $ textToJSString an, js_doubleJSVal d]
+                        pure $ jsval $ fromList [jsval $ textToJSString "AREF", jsval o]
         
                 O.setProp "type" (jsval ("Node" :: JSString)) o
                 O.setProp "tag" (jsval $ textToJSString $ unTag tag) o
-                O.setProp "ref" (ref') o
                 O.setProp "attributes" attributes' o
-                O.setProp "style" (jsval style') o
-                O.setProp "eventListeners" eventListeners' o
                 O.setProp "children" (jsval $ fromList newChildren) o
 
                 pure $ jsval o

--- a/pkg/hs/nauva/nauva.cabal
+++ b/pkg/hs/nauva/nauva.cabal
@@ -44,6 +44,8 @@ library
    , Nauva.Internal.Types
    , Nauva.DOM
    , Nauva.Internal.Events
+   , Nauva.View
+   , Nauva.View.Base
 
   build-depends:
      base >= 4.7 && < 5

--- a/pkg/hs/nauva/src/Nauva/DOM.hs
+++ b/pkg/hs/nauva/src/Nauva/DOM.hs
@@ -73,18 +73,17 @@ instance FromJSON Tag where
 --
 -- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
 
-data Attribute = Attribute
-    { attributeName :: !Text
-    , attributeValue :: !AttributeValue
-    } deriving (Eq, Ord)
+data Attribute
+    = AVAL !Text !AttributeValue
+    deriving (Eq, Ord)
 
 instance ToJSON Attribute where
-    toJSON (Attribute name value) = toJSON (name, value)
+    toJSON (AVAL name value) = toJSON (name, value)
 
 instance FromJSON Attribute where
     parseJSON v = do
         (name, value) <- parseJSON v
-        pure $ Attribute name value
+        pure $ AVAL name value
 
 
 
@@ -119,13 +118,13 @@ instance FromJSON AttributeValue where
 -- constructors.
 
 boolAttribute :: Text -> Bool -> Attribute
-boolAttribute name value = Attribute name (AVBool value)
+boolAttribute name value = AVAL name (AVBool value)
 
 stringAttribute :: Text -> Text -> Attribute
-stringAttribute name value = Attribute name (AVString value)
+stringAttribute name value = AVAL name (AVString value)
 
 intAttribute :: Text -> Int -> Attribute
-intAttribute name value = Attribute name (AVInt value)
+intAttribute name value = AVAL name (AVInt value)
 
 doubleAttribute :: Text -> Double -> Attribute
-doubleAttribute name value = Attribute name (AVDouble value)
+doubleAttribute name value = AVAL name (AVDouble value)

--- a/pkg/hs/nauva/src/Nauva/DOM.hs
+++ b/pkg/hs/nauva/src/Nauva/DOM.hs
@@ -12,16 +12,8 @@ module Nauva.DOM
     ( -- * Tag
       Tag(..)
 
-      -- * Attribute
-    , Attribute(..)
+      -- * AttributeValue
     , AttributeValue(..)
-
-      -- ** Attribute constructors
-      -- $attributeValueConstructors
-    , boolAttribute
-    , stringAttribute
-    , intAttribute
-    , doubleAttribute
     ) where
 
 
@@ -66,28 +58,6 @@ instance FromJSON Tag where
 
 
 --------------------------------------------------------------------------------
--- | We try to model attributes after IDL attributes (see the link below for
--- the difference between content attributes and IDL attributes). That means
--- we don't treat 'attributeValue' as a simple string, but instead explicitly
--- differentiate between the different types (String, Bool, Int, URL etc).
---
--- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
-
-data Attribute
-    = AVAL !Text !AttributeValue
-    deriving (Eq, Ord)
-
-instance ToJSON Attribute where
-    toJSON (AVAL name value) = toJSON (name, value)
-
-instance FromJSON Attribute where
-    parseJSON v = do
-        (name, value) <- parseJSON v
-        pure $ AVAL name value
-
-
-
---------------------------------------------------------------------------------
 data AttributeValue
     = AVBool !Bool
     | AVString !Text
@@ -110,21 +80,3 @@ instance FromJSON AttributeValue where
     parseJSON   (String s) = pure $ AVString s
     parseJSON v@(Number _) = (AVInt <$> parseJSON v) <|> (AVDouble <$> parseJSON v)
     parseJSON    _         = fail "AttributeValue"
-
-
--- $attributeValueConstructors
--- These constructors are here for convenience. You are encouraged to use
--- these functions instead of the 'Attribute' and 'AttributeValue'
--- constructors.
-
-boolAttribute :: Text -> Bool -> Attribute
-boolAttribute name value = AVAL name (AVBool value)
-
-stringAttribute :: Text -> Text -> Attribute
-stringAttribute name value = AVAL name (AVString value)
-
-intAttribute :: Text -> Int -> Attribute
-intAttribute name value = AVAL name (AVInt value)
-
-doubleAttribute :: Text -> Double -> Attribute
-doubleAttribute name value = AVAL name (AVDouble value)

--- a/pkg/hs/nauva/src/Nauva/Internal/Types.hs
+++ b/pkg/hs/nauva/src/Nauva/Internal/Types.hs
@@ -38,7 +38,7 @@ data Element where
     EText :: Text -> Element
     -- A text element.
 
-    ENode :: Tag -> Maybe Ref -> [Attribute] -> [EventListener] -> Style -> [Element] -> Element
+    ENode :: Tag -> [Attribute] -> [Element] -> Element
     -- An element representing a native DOM node.
 
     EThunk :: (Typeable p) => Thunk p -> p -> Element
@@ -63,7 +63,7 @@ data Element where
 data Instance where
     IText :: Text -> Instance
 
-    INode :: Tag -> Maybe Ref -> [Attribute] -> [EventListener] -> Style -> [(Key, Instance)] -> Instance
+    INode :: Tag -> [Attribute] -> [(Key, Instance)] -> Instance
 
     IThunk :: (Typeable p) => Thunk p -> p -> Instance -> Instance
     -- In the instance for 'EThunk', we remember the forced and instantiated
@@ -85,7 +85,7 @@ data Instance where
 
 data Spine where
     SText :: Text -> Spine
-    SNode :: Tag ->  Maybe Ref -> [Attribute] -> [EventListener] -> Style -> [(Key, Spine)] -> Spine
+    SNode :: Tag ->  [Attribute] -> [(Key, Spine)] -> Spine
     SComponent :: ComponentId -> [EventListener] -> Hooks h -> Spine -> Spine
 
 
@@ -93,13 +93,10 @@ instance A.ToJSON Spine where
     toJSON s = case s of
         (SText text) -> toJSON text
 
-        (SNode tag ref attrs eventListeners style children) -> object
+        (SNode tag attrs children) -> object
             [ "type" .= ("Node" :: String)
             , "tag" .= toJSON tag
-            , "ref" .= toJSON ref
             , "attributes" .= toJSON (map toJSON attrs)
-            , "style" .= toJSON style
-            , "eventListeners" .= toJSON (map toJSON eventListeners)
             , "children" .= toJSON (map toJSON children)
             ]
 

--- a/pkg/hs/nauva/src/Nauva/Static.hs
+++ b/pkg/hs/nauva/src/Nauva/Static.hs
@@ -48,7 +48,7 @@ elementToMarkup el = case el of
         let tagString = T.unpack $ unTag tag
             parent = B.Parent (fromString tagString) (fromString $ "<" <> tagString) (fromString $ "</" <> tagString <> ">")
             attrs = map toAttribute attributes
-            toAttribute (Attribute n v) = B.attribute (B.textTag n) (B.textTag $ " " <> n <> "=\"") $ case v of
+            toAttribute (AVAL n v) = B.attribute (B.textTag n) (B.textTag $ " " <> n <> "=\"") $ case v of
                 AVBool b -> B.textValue $ if b then "true" else "false"
                 AVString t -> B.textValue t
                 AVInt i -> B.stringValue $ show i

--- a/pkg/hs/nauva/src/Nauva/Static.hs
+++ b/pkg/hs/nauva/src/Nauva/Static.hs
@@ -44,7 +44,7 @@ elementToMarkup el = case el of
     (EText text) ->
         B.toMarkup text
 
-    (ENode tag _ attributes _ _ children) ->
+    (ENode tag attributes children) ->
         let tagString = T.unpack $ unTag tag
             parent = B.Parent (fromString tagString) (fromString $ "<" <> tagString) (fromString $ "</" <> tagString <> ">")
             attrs = map toAttribute attributes

--- a/pkg/hs/nauva/src/Nauva/View.hs
+++ b/pkg/hs/nauva/src/Nauva/View.hs
@@ -1,0 +1,5 @@
+module Nauva.View
+    ( module Nauva.View.Base
+    ) where
+
+import Nauva.View.Base

--- a/pkg/hs/nauva/src/Nauva/View/Base.hs
+++ b/pkg/hs/nauva/src/Nauva/View/Base.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+module Nauva.View.Base where
+
+
+import           Data.Text (Text)
+import           Data.Monoid
+import qualified Data.Aeson as A
+import           Data.Typeable
+
+import           Nauva.DOM
+import           Nauva.Internal.Types
+import           Nauva.Internal.Events
+import           Nauva.NJS
+
+
+class Term arg res | arg -> res where
+    term :: Text -> arg -> res
+
+
+instance Term Text Attribute where
+    term = stringAttribute
+
+instance Term Int Attribute where
+    term = intAttribute
+
+instance Term Style Attribute where
+    term _ = styleAttribute
+
+instance Term EventListener Attribute where
+    term _ = eventListenerAttribute
+
+instance Term Ref Attribute where
+    term _ = refAttribute
+
+
+instance Term [Attribute] ([Element] -> Element) where
+    term tag = ENode (Tag tag)
+
+instance Term [Element] Element where
+    term tag = ENode (Tag tag) []
+
+instance (Typeable p) => Term (Thunk p) (p -> Element) where
+    term _ = EThunk
+
+instance (Typeable p, A.FromJSON a, Value h, Value a) => Term (Component p h s a) (p -> Element) where
+    term _ = EComponent
+
+
+
+
+
+
+class With a where
+    with :: a -> [Attribute] -> a
+
+instance With Element where
+    with (ENode tag attrs children) extraAttrs = ENode tag (attrs <> extraAttrs) children
+    with el                         _          = el
+
+instance With ([Element] -> Element) where
+    with f extraAttrs = \arg -> case f arg of
+        (ENode tag attrs children) -> ENode tag (attrs <> extraAttrs) children
+        el                         -> el
+
+
+div_ :: Term arg res => arg -> res
+div_ = term "div"
+
+span_ :: Term arg res => arg -> res
+span_ = term "span"
+
+button_ :: Term arg res => arg -> res
+button_ = term "button"
+
+input_ :: Term arg res => arg -> res
+input_ = term "input"
+
+circle_ :: Term arg res => arg -> res
+circle_ = term "circle"
+
+svg_ :: Term arg res => arg -> res
+svg_ = term "svg"
+
+rect_ :: Term arg res => arg -> res
+rect_ = term "rect"
+
+style_ :: Term arg res => arg -> res
+style_ = term "style"
+
+value_ :: Term arg res => arg -> res
+value_ = term "value"
+
+width_ :: Term arg res => arg -> res
+width_ = term "width"
+
+height_ :: Term arg res => arg -> res
+height_ = term "height"
+
+r_ :: Term arg res => arg -> res
+r_ = term "r"
+
+x_ :: Term arg res => arg -> res
+x_ = term "x"
+
+y_ :: Term arg res => arg -> res
+y_ = term "y"
+
+cx_ :: Term arg res => arg -> res
+cx_ = term "cx"
+
+cy_ :: Term arg res => arg -> res
+cy_ = term "cy"
+
+fill_ :: Term arg res => arg -> res
+fill_ = term "fill"
+
+ref_ :: Term arg res => arg -> res
+ref_ = term "ref"
+
+className_ :: Term arg res => arg -> res
+className_ = term "className"
+
+br_ :: [Attribute] -> Element
+br_ = with (ENode "br" [] [])
+
+
+onMouseMove_ :: (A.ToJSON r, Value r) => F1 MouseEvent (EventHandler r) -> Attribute
+onMouseMove_ = AEVL . EventListener "mouseMove"
+
+onClick_ :: (A.ToJSON r, Value r) => F1 MouseEvent (EventHandler r) -> Attribute
+onClick_ = AEVL . EventListener "click"
+
+onChange_ :: (A.ToJSON r, Value r) => F1 MouseEvent (EventHandler r) -> Attribute
+onChange_ = AEVL . EventListener "change"
+
+
+str_ :: Text -> Element
+str_ = EText
+
+thunk_ :: Term arg res => arg -> res
+thunk_ = term "thunk"
+
+component_ :: Term arg res => arg -> res
+component_ = term "component"


### PR DESCRIPTION
Experimenting with API like Lucid has for building elements. Greatly simplifies API surface:

## Nodes

Old | New
--- | ---
`ENode "br" Nothing [] [] noStyle []` | `br_ []`
`ENode "div" Nothing [] [] rootStyle [...]` | `div_ [style_ rootStyle] [...]`
`EThunk someThunk props` | `thunk_ someThunk props`


## Attributes

Old | New
--- | ---
`Attribute "value" (AVString t)` | `value_ t`
`intAttribute "x" 0` | `x_ 0`