### PR TITLE
Allow components to receive input from outside

### DIFF
--- a/examples/playground/app/src/Nauva/Playground/App.hs
+++ b/examples/playground/app/src/Nauva/Playground/App.hs
@@ -90,7 +90,7 @@ component :: Component Int () (Int, Text) Action
 component = Component
     { componentId = mkComponentId
     , componentDisplayName = "app-display-name"
-    , initialComponentState = \i -> (i, "")
+    , initialComponentState = \i -> pure ((i, ""), [])
     , componentEventListeners = \_ -> []
     , componentHooks = constHooks
     , receiveProps = receiveProps'
@@ -109,7 +109,7 @@ component = Component
     update' (DoClick t) (i, _) = ((i, t), [pure DoThis])
     update' (DoChange t) (i, _) = ((i, t), [pure DoThis])
 
-    receiveProps' p (_, t) = ((p, t), [pure DoThat])
+    receiveProps' p (_, t) = pure ((p, t), [], [pure DoThat])
 
     view :: (Int, Text) -> Element
     view (i, t) = span_
@@ -205,7 +205,7 @@ canvas = Component
     , componentDisplayName = "Canvas"
     , initialComponentState = \_ ->
         let refKey = mkRefKey
-        in CanvasS (0,0) refKey (onResizeHandler refKey) Nothing
+        in pure (CanvasS (0,0) refKey (onResizeHandler refKey) Nothing, [])
     , componentEventListeners = \(CanvasS _ _ onResizeH _) ->
         [onResize onResizeH]
     , componentHooks = Hooks
@@ -225,7 +225,7 @@ canvas = Component
     update' (Mouse x y)   (CanvasS _ refKey onResizeH s) = (CanvasS (x, y - 100) refKey onResizeH s, [])
     update' (SetSize w h) (CanvasS m refKey onResizeH _) = (CanvasS m refKey onResizeH (Just (floor w, floor h)), [])
 
-    receiveProps' () s = (s, [])
+    receiveProps' () s = pure (s, [], [])
 
     numCircles = 100
 

--- a/examples/playground/server/src/Main.hs
+++ b/examples/playground/server/src/Main.hs
@@ -13,7 +13,7 @@ import           Nauva.Playground.App
 
 main :: IO ()
 main = do
-    runServer $ Config 8000 (rootElement 1) Nothing $ do
+    runServer $ Config 8000 (\_ -> rootElement 1) Nothing $ do
         H.style $ mconcat
             [ "*, *:before, *:after { box-sizing: inherit; }"
             , "html { box-sizing: border-box; }"

--- a/pkg/hs/nauva-dev-server/public/nauva-dev-server.js
+++ b/pkg/hs/nauva-dev-server/public/nauva-dev-server.js
@@ -67,6 +67,9 @@ function loadingScreen() {
 }
 function runClient() {
     const ws = new WebSocket('ws://localhost:8000/ws');
+    ws.addEventListener('open', () => {
+        ws.send(JSON.stringify(['location', window.location.pathname]));
+    });
     ws.addEventListener('message', msg => {
         // console.time('JSON.parse');
         const data = JSON.parse(msg.data);

--- a/pkg/hs/nauva-dev-server/public/nauva-dev-server.ts
+++ b/pkg/hs/nauva-dev-server/public/nauva-dev-server.ts
@@ -105,6 +105,10 @@ function loadingScreen() {
 function runClient() {
     const ws = new WebSocket('ws://localhost:8000/ws');
 
+    ws.addEventListener('open', () => {
+        ws.send(JSON.stringify(['location', window.location.pathname]));
+    });
+
     ws.addEventListener('message', msg => {
         // console.time('JSON.parse');
         const data = JSON.parse(msg.data);
@@ -299,7 +303,7 @@ const cssRules: Set<string> = new Set();
 
 const emitRule = (rule: any): string => {
     const {hash} = rule;
-    
+
     if (!cssRules.has(hash)) {
         cssRules.add(hash);
         const text = cssRuleExText(rule);
@@ -391,7 +395,7 @@ function spineToReact(ws, path, ctx: Context, spine, key) {
                     switch (v[0]) {
                     case 1: return emitRule({ type: v[0], hash: v[1], conditions: v[2], suffixes: v[3], cssDeclarations: v[4] });
                     case 5: return emitRule({ type: v[0], hash: v[1], cssDeclarations: v[2] });
-                    } 
+                    }
                 }).filter(x => x !== undefined).join(" ");
             } else if (k === 'AREF') {
                 props.ref = getFn(ctx, path, 'ref', () => {

--- a/pkg/hs/nauva/nauva.cabal
+++ b/pkg/hs/nauva/nauva.cabal
@@ -48,6 +48,7 @@ library
    , Nauva.View.HTML
    , Nauva.View.Types
    , Nauva.View.Terms
+   , Nauva.Service.Router
 
   build-depends:
      base >= 4.7 && < 5

--- a/pkg/hs/nauva/src/Nauva/Service/Router.hs
+++ b/pkg/hs/nauva/src/Nauva/Service/Router.hs
@@ -1,0 +1,25 @@
+module Nauva.Service.Router
+    ( RouterH(..)
+    , Location(..)
+    ) where
+
+
+import Data.Text (Text)
+import Control.Concurrent.STM
+
+
+
+data RouterH = RouterH
+    { hLocation :: (TVar Location, TChan Location)
+      -- ^ The current 'Location' and a (broadcast) 'TChan' which can
+      -- be subscribed to in order to receive notifications when the location
+      -- changes.
+
+    , hPush :: Text -> IO ()
+      -- ^ Push a new URL to the router stack.
+    }
+
+
+data Location = Location
+    { locPathname :: !Text
+    }


### PR DESCRIPTION
These inputs (signals) are derived from props and provide an additional
source of actions which can change the component state. One example
is provided: Nauva.Service.Router. It represents the current location
(pathname). It can be used by a component to decide which page to
render.