### PR TITLE
Replace playground with varna

### DIFF
--- a/app/varna/dev/app-varna-dev.cabal
+++ b/app/varna/dev/app-varna-dev.cabal
@@ -1,0 +1,30 @@
+name:                app-varna-dev
+version:             0.0.0
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable app-varna-dev
+  default-language:    Haskell2010
+  main-is:             src/Main.hs
+
+  build-depends:
+     base >= 4.7 && < 5
+   , aeson
+   , bytestring
+   , safe
+   , text
+   , mtl
+   , stm
+   , containers
+   , blaze-markup
+   , blaze-html
+   , data-default
+   , nauva
+   , tagged
+   , random
+   , nauva-dev-server
+   , nauva-catalog
+   , app-varna-shared
+   , markdown
+   , conduit
+   , bytestring

--- a/app/varna/dev/src/Main.hs
+++ b/app/varna/dev/src/Main.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE QuasiQuotes           #-}
+
+module Main (main, catalogMain) where
+
+
+import           Data.ByteString    (ByteString)
+import qualified Data.ByteString    as BS
+import           Data.Text          (Text)
+import qualified Data.Text.Encoding as T
+import           Text.Markdown      (def, MarkdownSettings(..))
+import           Text.Markdown.Block
+import           Text.Markdown.Inline
+import           Data.Conduit
+import qualified Data.Conduit.List as CL
+import           Data.Functor.Identity (runIdentity)
+
+import qualified Text.Blaze.Html5            as H
+import qualified Text.Blaze.Html5.Attributes as A
+
+import           Nauva.Server
+import           Nauva.DOM
+import           Nauva.Internal.Types
+import           Nauva.Internal.Events
+import           Nauva.NJS
+import           Nauva.View
+
+import           Nauva.Catalog
+import           Nauva.Catalog.Types
+import           Nauva.Catalog.TH
+import           Nauva.Catalog.Shell
+import           Nauva.Catalog.Elements
+
+import           App.Varna.Shared
+
+import           App.Varna.Element.Card as Card
+
+
+
+main :: IO ()
+main = do
+    runServer $ Config 8000 (\_ -> rootElement 1) Nothing $ do
+        H.script H.! A.src "https://use.typekit.net/ubj7dti.js" $ ""
+        H.script "try{Typekit.load({ async: true });}catch(e){}"
+
+        H.style $ mconcat
+            [ "*, *:before, *:after { box-sizing: inherit; }"
+            , "html { box-sizing: border-box; }"
+            , "body { margin: 0; }"
+            ]
+
+
+catalogMain :: IO ()
+catalogMain = do
+    runServer $ Config 8000 (\routerH -> catalog $ CatalogProps routerH catalogPages) Nothing $ do
+        H.link H.! A.rel "stylesheet" H.! A.type_ "text/css" H.! A.href "https://fonts.googleapis.com/css?family=Roboto:400,700,400italic"
+        H.link H.! A.rel "stylesheet" H.! A.type_ "text/css" H.! A.href "https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700"
+
+        H.script H.! A.src "https://use.typekit.net/ubj7dti.js" $ ""
+        H.script "try{Typekit.load({ async: true });}catch(e){}"
+
+        H.style $ mconcat
+            [ "*, *:before, *:after { box-sizing: inherit; }"
+            , "html { box-sizing: border-box; }"
+            , "body { margin: 0; }"
+            ]
+
+
+catalogPages :: [Page]
+catalogPages =
+    [ PLeaf $ Leaf
+        { leafHref = "/"
+        , leafTitle = "Introduction"
+        , leafElement = introductionPage
+        }
+    , PDirectory $ Directory
+        { directoryTitle = "Elements"
+        , directoryChildren =
+            [ Leaf
+                { leafHref = "/elements/card"
+                , leafTitle = "Card"
+                , leafElement = Card.catalogPage
+                }
+            ]
+        }
+    ]
+
+introductionPage :: Element
+introductionPage = [nauvaCatalogPage|
+# Welcome to the Varna catalog
+|]

--- a/app/varna/shared/app-varna-shared.cabal
+++ b/app/varna/shared/app-varna-shared.cabal
@@ -1,0 +1,18 @@
+name:                app-varna-shared
+version:             0.0.0
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+
+  exposed-modules:
+     App.Varna.Shared
+   , App.Varna.Element.Card
+
+  build-depends:
+     base >= 4.7 && < 5
+   , text
+   , containers
+   , nauva

--- a/app/varna/shared/src/App/Varna/Element/Card.hs
+++ b/app/varna/shared/src/App/Varna/Element/Card.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+
+module App.Varna.Element.Card
+    ( batteryCard
+
+    , batteryCardBodyParagraph
+    , batteryCardBodyPrimaryButton
+    , batteryCardBodySecondaryButton
+
+    , catalogPage
+    ) where
+
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Aeson as A
+import           Data.Monoid
+import qualified Data.Map as M
+import           Data.Tagged
+
+import           Control.Monad
+
+import           System.Random
+
+import           GHC.Generics (Generic)
+
+import           Nauva.DOM
+import           Nauva.Internal.Types
+import           Nauva.Internal.Events
+import           Nauva.NJS
+import           Nauva.View
+
+import           Nauva.Catalog.Elements
+import           Nauva.Catalog.TH (nauvaCatalogPage)
+
+import           Prelude hiding (rem)
+
+
+
+batteryCard :: [Element] -> Element
+batteryCard body = div_ [style_ rootStyle] $ [batteryCardBody body]
+  where
+    rootStyle :: Style
+    rootStyle = mkStyle $ do
+        margin (rem 0.5)
+        width "calc(100vw - 16px)"
+        height (rem 12)
+
+        display flex
+
+        -- min: 254px -> 260px
+        media "(min-width: 552px) and (max-width: 827px)" $ do
+            width "calc((100vw - 32px) / 2)"
+
+        media "(min-width: 828px) and (max-width: 1167px)" $ do
+            width "calc((100vw - 48px) / 3)"
+
+        media "(min-width: 1168px)" $ do
+            width "calc((100vw - 64px) / 4)"
+
+
+batteryCardBody :: [Element] -> Element
+batteryCardBody body = div_ [style_ style] $ [batteryTileHeader] ++ body
+  where
+    style = mkStyle $ do
+        flex "1"
+        display flex
+        flexDirection column
+        backgroundColor "rgb(240, 239, 244)"
+
+
+batteryTileHeader :: Element
+batteryTileHeader = div_ [style_ rootStyle]
+    [ indicator
+    , batId
+    , meta
+    ]
+  where
+    rootStyle :: Style
+    rootStyle = mkStyle $ do
+        display flex
+        flexDirection row
+
+        backgroundColor "rgb(45, 48, 57)"
+        color "rgb(236, 225, 233)"
+
+        backgroundColor "#1f633c"
+
+    indicatorStyle :: Style
+    indicatorStyle = mkStyle $ do
+        width (rem 1.5)
+        height (rem 3)
+
+        backgroundColor "rgb(158, 156, 156)"
+        color "rgb(236, 225, 233)"
+
+        lineHeight (rem 3)
+        fontSize (rem 2.2)
+        textAlign center
+
+        backgroundColor "#28b262"
+
+    indicator = div_ [style_ indicatorStyle] []
+
+    batIdStyle :: Style
+    batIdStyle = mkStyle $ do
+        flex "1"
+        fontSize (rem 2.2)
+        lineHeight (rem 3)
+        marginLeft (rem 0.6)
+
+    batId = div_ [style_ batIdStyle] [str_ "XXX"]
+
+    metaStyle :: Style
+    metaStyle = mkStyle $ do
+        display flex
+        flexDirection column
+        textAlign right
+        marginRight (rem 0.3)
+
+    meta = div_ [style_ metaStyle]
+        [ metaRow "3S / 1500mAh"
+        , metaRow "4.198V"
+        ]
+
+
+    metaRow s = div_ [style_ metaRowStyle] [str_ s]
+
+    metaRowStyle :: Style
+    metaRowStyle = mkStyle $ do
+        height (rem 1.5)
+        lineHeight (rem 1.5)
+
+
+-- batteryCardBody :: [Element] -> Element
+-- batteryCardBody = div_ [style_ rootStyle]
+--   where
+--     rootStyle = mkStyle $ do
+--         flex "1"
+--         display flex
+--         justifyContent center
+--         flexDirection column
+--         alignItems center
+
+batteryCardBodyParagraph :: Bool -> [Element] -> Element
+batteryCardBodyParagraph centered = div_ [style_ rootStyle]
+  where
+    rootStyle = mkStyle $ do
+        margin (rem 0.0) (rem 0)
+        padding (rem 0) (rem 1)
+        flex "1"
+        when centered $ do
+            display flex
+            flexDirection column
+            justifyContent center
+            textAlign center
+
+batteryCardBodyPrimaryButton :: Text -> Element
+batteryCardBodyPrimaryButton label = div_ [style_ rootStyle] [str_ label]
+  where
+    rootStyle = mkStyle $ do
+        -- button
+        display inlineBlock
+        padding (rem 0.2) (rem 0.5) (rem 0.1)
+        backgroundColor "#ddd"
+        textAlign center
+        cursor pointer
+
+
+        -- battery-card-body-button
+        backgroundColor "rgb(226, 206, 226)"
+        color "rgb(37, 37, 32)"
+
+        fontSize (rem 1.5)
+        textTransform uppercase
+
+        padding (rem 0.5) (rem 1) (rem 0.4)
+
+        onHover $ do
+            backgroundColor "rgb(202, 174, 202)"
+
+batteryCardBodySecondaryButton :: Text -> Element
+batteryCardBodySecondaryButton label = div_ [style_ rootStyle] [str_ label]
+  where
+    rootStyle = mkStyle $ do
+        -- button
+        display inlineBlock
+        padding (rem 0.2) (rem 0.5) (rem 0.1)
+        backgroundColor "#ddd"
+        textAlign center
+        cursor pointer
+
+
+        -- battery-card-body-button
+        backgroundColor "rgb(226, 206, 226)"
+        color "rgb(37, 37, 32)"
+
+        fontSize (rem 1.5)
+        textTransform uppercase
+
+        padding (rem 0.5) (rem 1) (rem 0.4)
+
+
+        -- battery-card-body-button-secondary
+        backgroundColor "rgb(136, 113, 136)"
+        color "white"
+        fontSize (rem 0.75)
+
+        onHover $ do
+            backgroundColor "rgb(112, 86, 112)"
+
+
+catalogPage :: Element
+catalogPage = [nauvaCatalogPage|
+# Overview
+
+A `batteryCardBody` is the container for the body elements. It is epected to be placed
+in a flex container and expands to the size to its container (`flex:1`).
+
+The minimum dimensions are `254px` wide and `12rem` tall, but ideally `20rem` by `14rem`.
+
+```nauva
+div_ [style_ $ mkStyle (display flex >> flexDirection row >> justifyContent "space-between")]
+    [ div_ [style_ $ mkStyle (display flex >> width "254px" >> height "12rem")] [batteryCardBody []]
+    , div_ [style_ $ mkStyle (display flex >> width "20rem" >> height "14em")] [batteryCardBody []]
+    ]
+```
+
+# Body Elements
+
+You can place any of these elements into the card body:
+
+ - `batteryCardBodyParagraph`
+ - `batteryCardBodyPrimaryButton`
+ - `batteryCardBodySecondaryButton`
+
+```nauva
+div_ [style_ $ mkStyle (display flex >> width "20rem" >> height "14rem")]
+    [ batteryCardBody
+        [ batteryCardBodyParagraph True [str_ "This looks like a fresh battery. Congratulations on your purchase."]
+        , batteryCardBodyPrimaryButton "charge battery"
+        , batteryCardBodySecondaryButton "discharge battery"
+        ]
+    ]
+```
+|]

--- a/app/varna/shared/src/App/Varna/Shared.hs
+++ b/app/varna/shared/src/App/Varna/Shared.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+
+module App.Varna.Shared
+    ( rootElement
+
+    , batteryCard
+    ) where
+
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Aeson as A
+import           Data.Monoid
+import qualified Data.Map as M
+import           Data.Tagged
+
+import           Control.Monad
+
+import           System.Random
+
+import           GHC.Generics (Generic)
+
+import           Nauva.DOM
+import           Nauva.Internal.Types
+import           Nauva.Internal.Events
+import           Nauva.NJS
+import           Nauva.View
+
+import           App.Varna.Element.Card
+
+import           Prelude hiding (rem)
+
+
+
+rootElement :: Int -> Element
+rootElement i = div_ [style_ rootStyle] $
+    [ navbar
+    , batteries
+        [ batteryCard
+            [ batteryCardBodyParagraph True [str_ "This looks like a fresh battery. Congratulations on your purchase."]
+            , batteryCardBodyPrimaryButton "charge battery"
+            , batteryCardBodySecondaryButton "discharge battery"
+            ]
+        , batteryCard []
+        , batteryCard []
+        , batteryCard []
+        , batteryCard []
+        , batteryCard []
+        , batteryCard []
+        , batteryCard []
+        , batteryCard []
+        , batteryCard []
+        , batteryCard []
+        ]
+    ]
+
+  where
+    rootStyle :: Style
+    rootStyle = mkStyle $ do
+        height (vh 100)
+        display flex
+        flexDirection column
+        fontFamily "museo-slab, serif"
+
+
+navbar :: Element
+navbar = div_ [style_ rootStyle]
+    [ div_ [style_ navbarItemStyle] [ str_ "Home" ]
+    , div_ [style_ navbarItemStyle] [ str_ "Create Battery" ]
+    ]
+  where
+    rootStyle :: Style
+    rootStyle = mkStyle $ do
+        display flex
+        flexDirection row
+        height (rem 3)
+        backgroundColor "rgb(126, 120, 3)"
+        color "rgb(228, 228, 238)"
+        fontSize (rem 1.8)
+        lineHeight (rem 3)
+
+    navbarItemStyle :: Style
+    navbarItemStyle = mkStyle $ do
+        padding (rem 0) (rem 0.5)
+        cursor pointer
+
+        onHover $ do
+            backgroundColor "#999"
+
+
+batteries :: [Element] -> Element
+batteries = div_ [style_ rootStyle]
+  where
+    rootStyle = mkStyle $ do
+        marginTop (rem 1)
+        display flex
+        flexDirection row
+        flexWrap wrap

--- a/examples/playground/native/src/Main.hs
+++ b/examples/playground/native/src/Main.hs
@@ -1,9 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main (main) where
 
-import Nauva.Client
-import Nauva.Playground.App
+
+import qualified Text.Blaze.Html            as H
+import qualified Text.Blaze.Html.Attributes as A
+
+import           Nauva.Client
+import           Nauva.Playground.App
+
+
 
 main :: IO ()
 main = do
     putStrLn "Native App"
-    runClient (Config (rootElement 1))
+    runClient (Config (rootElement 1)) Nothing $ do
+        H.style $ mconcat
+            [ "*, *:before, *:after { box-sizing: inherit; }"
+            , "html { box-sizing: border-box; }"
+            , "body { margin: 0; }"
+            ]

--- a/pkg/hs/nauva-native/src/Nauva/Client.hs
+++ b/pkg/hs/nauva-native/src/Nauva/Client.hs
@@ -10,6 +10,7 @@ module Nauva.Client
 
 import           Data.Default
 import           Data.Text               (Text)
+import qualified Data.Text               as T
 import qualified Data.Text.Encoding      as T
 import qualified Data.Text.Lazy.Encoding as LT
 import qualified Data.Aeson              as A
@@ -25,6 +26,7 @@ import           Control.Concurrent
 import           Control.Concurrent.STM
 import           Control.Monad
 import           Control.Monad.Except
+import           Control.Monad.Writer.Lazy
 
 import           System.IO.Unsafe
 
@@ -348,8 +350,8 @@ instanceToJSVal = go []
                     ASTY style -> unsafePerformIO $ do
                         style' <- O.create
 
-                        forM_ (M.toList style) $ \(k, v) ->
-                            O.setProp (JSS.pack k) (jsval $ JSS.pack v) style'
+                        forM_ (execWriter $ runStyle style) $ \(k, v) ->
+                            O.setProp (JSS.pack $ T.unpack k) (jsval $ JSS.pack $ T.unpack $ unCSSValue v) style'
 
                         pure $ jsval $ fromList [jsval $ textToJSString "ASTY", (jsval style')]
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,8 +4,9 @@ packages:
 - pkg/hs/nauva-catalog
 - pkg/hs/nauva-css
 - pkg/hs/nauva-dev-server
-- examples/playground/app
-- examples/playground/server
+
+- app/varna/shared
+- app/varna/dev
 
 extra-deps:
 - snap-blaze-0.2.1.4


### PR DESCRIPTION
Varna consists of some small pieces extracted from one of my internal projects.
I've used this for a while to see where the general Nauva API is insufficient
and needs improvement. In particular, the work on nauva-css was largely driven
by the needs of Varna.

Also, this is the first app which features the catalog. Run 'catalogMain' instead
of 'main' (or ':main') to start the catalog. Native builds are not supported yet.