### PR TITLE
Rename typeFace to typeface

### DIFF
--- a/pkg/hs/nauva-catalog/src/Nauva/Catalog/Elements.hs
+++ b/pkg/hs/nauva-catalog/src/Nauva/Catalog/Elements.hs
@@ -393,7 +393,7 @@ typefaceSpecimen t tf = pageElement
         ]
 
     previewStyle = mkStyle $ do
-        typeFace tf
+        typeface tf
         padding "20px"
         backgroundColor "white"
         border "1px solid #eee"

--- a/pkg/hs/nauva-css/src/Nauva/CSS/Typeface.hs
+++ b/pkg/hs/nauva-css/src/Nauva/CSS/Typeface.hs
@@ -3,6 +3,7 @@
 module Nauva.CSS.Typeface
     ( Typeface(..)
     , typeface
+    , typeFace
     ) where
 
 
@@ -53,3 +54,6 @@ typeface (Typeface {..}) = do
     fontWeight tfFontWeight
     fontSize tfFontSize
     lineHeight tfLineHeight
+
+{-# DEPRECATED typeFace "Use typeface instead of typeFace (with capital F)" #-}
+typeFace = typeface

--- a/pkg/hs/nauva-css/src/Nauva/CSS/Typeface.hs
+++ b/pkg/hs/nauva-css/src/Nauva/CSS/Typeface.hs
@@ -2,7 +2,7 @@
 
 module Nauva.CSS.Typeface
     ( Typeface(..)
-    , typeFace
+    , typeface
     ) where
 
 
@@ -41,12 +41,14 @@ data Typeface = Typeface
 
 -- | Apply the given 'Typeface' in a CSS block.
 --
+-- > someTypeface = Typeface "brandBodyCopy" "Helvetica, sans-serif" "normal" "16px" "1.4"
+--
 -- > rootStyle = mkStyle $ do
--- >     typeFace someTypeFace
+-- >     typeface someTypeface
 -- >     color "black"
 
-typeFace :: Typeface -> Writer [Statement] ()
-typeFace (Typeface {..}) = do
+typeface :: Typeface -> Writer [Statement] ()
+typeface (Typeface {..}) = do
     fontFamily tfFontFamily
     fontWeight tfFontWeight
     fontSize tfFontSize


### PR DESCRIPTION
In English, "typeface" is one word and we also use "Typeface" as the data type. So, to remove confusion, I suggest to use the "typeface" spelling instead of "typeFace".